### PR TITLE
Add progress growth direction control

### DIFF
--- a/Example/Example/Status.swift
+++ b/Example/Example/Status.swift
@@ -1,0 +1,64 @@
+//
+//  Status.swift
+//  Example
+//
+//  Created by Pierre Janineh on 16/05/2025.
+//
+
+import SwiftUI
+import ProgressUI
+
+enum Status: CaseIterable, Progressable {
+	case Excellent
+	case Normal
+	case SemiNormal
+	case Bad
+	case Critical
+	case Danger
+	
+	/**
+	 Get status color.
+	 */
+	var color: Color {
+		return switch(self){
+			case .Excellent:	.green.opacity(0.8)
+			case .Normal:		.yellow.opacity(0.8)
+			case .SemiNormal:	.orange.opacity(0.8)
+			case .Bad:			.red.opacity(0.8)
+			case .Critical:		.purple.opacity(0.8)
+			case .Danger:		.black.opacity(0.8)
+		}
+	}
+	
+	/**
+	 Get status color.
+	 */
+	var innerColor: Color? {
+		return switch(self){
+			case .Excellent:	.green
+			case .Normal:		.yellow
+			case .SemiNormal:	.orange
+			case .Bad:			.red
+			case .Critical:		.purple
+			case .Danger:		.black
+		}
+	}
+	
+	/**
+	 Static func to get instance of enum by providing progress
+	 - Parameters:
+	 - progress: CGFloat (0.0 - 1.0) progress percentage in decimal.
+	 */
+	static func calculate(from progress: CGFloat) -> Status {
+		let level: CGFloat = CGFloat(1) / CGFloat(Status.allCases.count)
+		
+		return switch progress {
+			case 0...level:						Excellent
+			case level...(level * 2): 			Normal
+			case (level * 2)...(level * 3):		SemiNormal
+			case (level * 3)...(level * 4):		Bad
+			case (level * 4)...(level * 5):		Critical
+			default:							Danger
+		}
+	}
+}

--- a/Sources/ProgressUI/Components/CircularProgress.swift
+++ b/Sources/ProgressUI/Components/CircularProgress.swift
@@ -87,8 +87,8 @@ internal struct CircularProgress: View, BaseProgress {
 					path.addRelativeArc(
 						center: center,
 						radius: radius,
-						startAngle: Angle(degrees: -90),
-						delta: Angle(degrees: options.isClockwise ? 360 : -360)
+						startAngle: startAngle,
+						delta: delta
 					)
 				}
 				
@@ -98,7 +98,7 @@ internal struct CircularProgress: View, BaseProgress {
 				
 				//MARK: - Progress
 				path
-					.trim(from: 0, to: progress)
+					.trim(from: start, to: end)
 					.stroke(
 						color,
 						style: StrokeStyle(
@@ -115,7 +115,7 @@ internal struct CircularProgress: View, BaseProgress {
 				//MARK: - Inner
 				if let innerColor {
 					path
-						.trim(from: 0, to: progress)
+						.trim(from: start, to: end)
 						.stroke(
 							innerColor,
 							style: StrokeStyle(
@@ -139,6 +139,43 @@ internal struct CircularProgress: View, BaseProgress {
 			} else {
 				rotationAngle = .degrees(rotationAngle.degrees - vm.pixelsPerStep)
 			}
+		}
+	}
+	
+	private var startAngle: Angle {
+		switch options.growFrom {
+			case .start, .end: .degrees(-90)
+			case .center: .degrees(90)
+		}
+	}
+	
+	private var delta: Angle {
+		let degrees: Double = switch options.growFrom {
+			case .start: -360
+			case .end, .center: 360
+		}
+		return Angle(degrees: degrees)
+	}
+	
+	private var start: CGFloat {
+		switch options.growFrom {
+			case .start, .end:
+				return 0
+			case .center:
+				let mid: CGFloat = 0.5
+				let half = progress / 2
+				return (mid - half).clamped(to: 0...1)
+		}
+	}
+	
+	private var end: CGFloat {
+		switch options.growFrom {
+			case .start, .end:
+				return progress
+			case .center:
+				let mid: CGFloat = 0.5
+				let half = progress / 2
+				return (mid + half).clamped(to: 0...1)
 		}
 	}
 }

--- a/Sources/ProgressUI/Components/ProgressUI/ProgressUI+Modifiers.swift
+++ b/Sources/ProgressUI/Components/ProgressUI/ProgressUI+Modifiers.swift
@@ -113,25 +113,45 @@ extension ProgressUI {
 		return copy
 	}
 	
-	/// Sets whether the progress arc should be drawn clockwise.
-	/// - Parameter isClockwise: Whether to draw clockwise (default: true).
+	/// Sets whether the progress arc should be rotated clockwise when spinning.
+	/// - Parameter isClockwise: Whether to spin clockwise (default: true).
 	/// - Returns: A modified ProgressUI instance.
 	///
 	/// Default: `true`.
+	@available(*, deprecated, message: "Use `.setIsSpinner(_:isClockwise:)` instead.")
 	public func setIsClockwise(_ isClockwise: Bool = true) -> Self {
+#if DEBUG
+		print("⚠️ [Deprecated] `setIsClockwise(\(isClockwise))` is deprecated. Use `.setIsSpinner(isClockwise:\(isClockwise))` instead.")
+#endif
 		var copy = self
 		copy.options.isClockwise = isClockwise
 		return copy
 	}
 	
+	/// Sets the direction the progress arc growth.
+	/// - Parameter from: Growing animation direction (default: .end).
+	/// - Returns: A modified ProgressUI instance.
+	///
+	/// Default: ``ProgressUI/GrowDirection/end.
+	///
+	/// > Setting this value to ``ProgressUI/GrowDirection/center`` with rotation 
+	public func setGrow(from direction: GrowDirection = .end) -> Self {
+		var copy = self
+		copy.options.growFrom = direction
+		return copy
+	}
+	
 	/// Sets whether the progress indicator should spin (spinner mode).
-	/// - Parameter isSpinner: Whether to enable spinner mode (default: true).
+	/// - Parameters:
+	///    - isSpinner: Whether to enable spinner mode (default: true).
+	///    - isClockwise: Whether to the spinning animation direction is clockwise (default: true).
 	/// - Returns: A modified ProgressUI instance.
 	///
 	/// Default: `false`.
-	public func setIsSpinner(_ isSpinner: Bool = true) -> Self {
+	public func setIsSpinner(_ isSpinner: Bool = true, isClockwise: Bool = true) -> Self {
 		var copy = self
 		copy.options.isSpinner = isSpinner
+		copy.options.isClockwise = isClockwise
 		return copy
 	}
 	

--- a/Sources/ProgressUI/GrowDirection.swift
+++ b/Sources/ProgressUI/GrowDirection.swift
@@ -1,0 +1,25 @@
+//
+//  GrowDirection.swift
+//  ProgressUI
+//
+//  Created by Pierre Janineh on 16/05/2025.
+//
+
+import SwiftUI
+
+/// The progress' growing direction.
+@frozen
+public enum GrowDirection {
+	/// Grows from start (leading)
+	case start
+	/// Grows from center (perfect for spinners)
+	case center
+	/// Grows from end (trailing)
+	case end
+	
+	internal var alignment: Alignment { switch self {
+		case .start: .leading
+		case .center: .center
+		case .end: .trailing
+	}}
+}

--- a/Sources/ProgressUI/Options.swift
+++ b/Sources/ProgressUI/Options.swift
@@ -95,13 +95,22 @@ public struct Options {
 	public var isRounded: Bool = true
 	
 	/**
-	 Determines whether the progress animation should be clockwise.
+	 Determines whether the progress spinning animation should be clockwise.
 	 
 	 Default: `true`.
 	 
-	 > You can set this with the modifier ``ProgressUI/ProgressUI/setIsClockwise(_:)``.
+	 > You can set this with the modifier ``ProgressUI/ProgressUI/setIsSpinner(_:isClockwise:)``.
 	 */
 	public var isClockwise: Bool = true
+	
+	/**
+	 Determines where the growing animation should go.
+	 
+	 Default: ``ProgressUI/GrowDirection/end.
+	 
+	 > You can set this with the modifier ``ProgressUI/ProgressUI/setGrow(from:)``.
+	 */
+	public var growFrom: GrowDirection = .end
 	
 	//MARK: - Spinner
 	/**
@@ -109,7 +118,7 @@ public struct Options {
 	 
 	 Default: `false`.
 	 
-	 > You can set this with the modifier ``ProgressUI/ProgressUI/setIsSpinner(_:)``.
+	 > You can set this with the modifier ``ProgressUI/ProgressUI/setIsSpinner(_:isClockwise:)``.
 	 */
 	public var isSpinner: Bool = false
 	

--- a/Sources/ProgressUI/Shape.swift
+++ b/Sources/ProgressUI/Shape.swift
@@ -7,7 +7,10 @@
 
 import SwiftUI
 
+/// The shape of the progress.
 public enum Shape {
+	/// Circular shape
 	case circular
+	/// Linear shape (progress bar)
 	case linear(_ hPadding: CGFloat = 15)
 }


### PR DESCRIPTION
- Add support for configurable progress growth direction (start, end, center)
- Implement start and end angle calculations for different growth modes
- Add proper trimming and rotation handling for each growth direction
- Maintain existing clockwise/counter-clockwise functionality

This enhancement allows users to control how the progress indicator fills, supporting growth from start, end, or center positions, making the progress UI more versatile for different use cases.