### PR TITLE
Public Options init, tests, CI matrix, DocC Pages & contributor docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -13,7 +13,6 @@ body:
       label: Describe the bug..
       description: Also tell us, what did you expect to happen?
       placeholder: Tell us what you see!
-      value: "A bug happened!"
     validations:
       required: true
   - type: textarea
@@ -45,9 +44,17 @@ body:
     validations:
       required: true
   - type: input
+    id: version
+    attributes:
+      label: Which ProgressUI version are you using?
+      description: The release tag, or the commit SHA if building from a branch.
+      placeholder: "1.2.0"
+    validations:
+      required: true
+  - type: input
     id: xcode
     attributes:
       label: What Xcode version do you use?
-      placeholder: "16.0"
+      placeholder: "26.0"
     validations:
       required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,11 +30,12 @@ _Select all that apply:_
 - [ ] Other: ___
 
 **Test Configuration**
-- OS: `iOS 18`
+- OS: `iOS 26`
 - Device: `iPhone 16`
-- Environment: `Simulator, Xcode 15`
+- Environment: `Simulator, Xcode 26`
 - Additional notes: `e.g. Dark mode, background refresh, etc.`
-- ---
+
+---
 
 ## 📎 Checklist  
 Please confirm the following before requesting review:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,15 @@ name: Build & Test
 on:
   pull_request:
     branches: [main, develop]
+  # `develop` is only ever reached via PR (already tested above), so build on
+  # push for `main` only — release merges/tags. Avoids double runs per merge.
   push:
-    branches: [main, develop]
+    branches: [main]
+
+# Cancel superseded runs for the same ref (e.g. rapid pushes to an open PR).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,19 +2,53 @@ name: Build & Test
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
 
 jobs:
-  build:
+  test:
+    name: SwiftPM build & test
     runs-on: macos-latest
-
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Show Xcode version
+      - name: Show toolchain versions
         run: |
           xcodebuild -version
           swift --version
 
-      - name: Build Swift Package
-        run: swift build --build-tests
+      - name: Build
+        run: swift build
+
+      - name: Test
+        run: swift test
+
+  platforms:
+    name: Build (${{ matrix.name }})
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: iOS
+            destination: 'generic/platform=iOS Simulator'
+          - name: macOS
+            destination: 'platform=macOS'
+          - name: macCatalyst
+            destination: 'platform=macOS,variant=Mac Catalyst'
+          - name: watchOS
+            destination: 'generic/platform=watchOS Simulator'
+          - name: tvOS
+            destination: 'generic/platform=tvOS Simulator'
+          - name: visionOS
+            destination: 'generic/platform=visionOS Simulator'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build ProgressUI for ${{ matrix.name }}
+        run: |
+          set -o pipefail
+          xcodebuild build \
+            -scheme ProgressUI \
+            -destination '${{ matrix.destination }}'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,49 @@
+name: Documentation
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Allow the workflow to publish to GitHub Pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only one Pages deployment at a time; cancel superseded runs.
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build DocC
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate documentation
+        run: |
+          swift package --allow-writing-to-directory ./docs \
+            generate-documentation \
+            --target ProgressUI \
+            --disable-indexing \
+            --transform-for-static-hosting \
+            --hosting-base-path ProgressUI \
+            --output-path ./docs
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs
+
+  deploy:
+    name: Deploy to Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ DerivedData/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+# Resolved versions — library does not pin a lockfile for consumers.
+Package.resolved
+# Generated DocC site (built and deployed by the Documentation workflow).
+/docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   initializer, `Progressable.calculate(from:)` bucketing, and `GrowDirection`
   alignment mapping.
 - DocC catalog with a landing page and curated topics.
+- DocC documentation published to GitHub Pages via a Documentation workflow
+  (using `swift-docc-plugin`).
 - Contribution guide, issue/PR templates, and a `CHANGELOG`.
 
 ### Changed
 - CI now runs the test suite and builds across every supported platform
-  (iOS, macOS, macCatalyst, watchOS, tvOS, visionOS).
+  (iOS, macOS, macCatalyst, watchOS, tvOS, visionOS), and avoids redundant
+  runs (push builds `main` only; superseded runs are cancelled).
 
 ### Fixed
 - Corrected the README "Dynamic Colors" and "Customization Options" examples,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Public memberwise initializer for ``Options``, allowing consumers to construct
+  a configuration directly (e.g. `Options(progressColor: .blue)`) instead of
+  only through the `set…` modifiers.
+- Unit test target (`ProgressUITests`) covering `Options` defaults, the new
+  initializer, `Progressable.calculate(from:)` bucketing, and `GrowDirection`
+  alignment mapping.
+- DocC catalog with a landing page and curated topics.
+- Contribution guide, issue/PR templates, and a `CHANGELOG`.
+
+### Changed
+- CI now runs the test suite and builds across every supported platform
+  (iOS, macOS, macCatalyst, watchOS, tvOS, visionOS).
+
+### Fixed
+- Corrected the README "Dynamic Colors" and "Customization Options" examples,
+  which previously did not compile.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,35 @@
+# ProgressUI
+
+SwiftUI library providing a customizable circular/linear progress indicator. Distributed as a Swift Package (SPM).
+
+## Build & verify
+
+```bash
+swift build                    # build the library
+swift build -c release         # release build
+xcodebuild -scheme ProgressUI -destination 'platform=iOS Simulator,name=iPhone 15' build
+```
+
+There is no test target. To exercise changes interactively, open `Example/Example.xcodeproj` (iOS/macOS/watchOS targets) and run the `Example` scheme.
+
+## Layout
+
+- `Package.swift` — single library target `ProgressUI`. Supports iOS 14+, macOS 11+, macCatalyst 14+, watchOS 7+, tvOS 15+, visionOS 1+. Any new API must be available on all of these.
+- `Sources/ProgressUI/`
+  - `Components/ProgressUI/` — public entry point.
+    - `ProgressUI.swift` — the `ProgressUI` SwiftUI `View`.
+    - `ProgressUI+Modifiers.swift` — fluent `.option(...)` style modifiers.
+    - `ProgressUI+ViewModel.swift` — internal observable state.
+  - `Components/BaseProgress.swift` — shared shape/animation scaffolding.
+  - `Components/CircularProgress.swift`, `LinearProgress.swift` — the two `Shape` implementations selected via `Options.shape`.
+  - `Options.swift` — the single configuration struct passed into `ProgressUI`.
+  - `Progressable.swift` — protocol consumers implement to drive dynamic coloring (`color`, optional `innerColor`, `calculate(from:)`).
+  - `Shape.swift`, `GrowDirection.swift`, `ProgressSize.swift` — small enums used by `Options`.
+- `Example/` — multi-platform sample app demonstrating usage.
+
+## Conventions
+
+- Public API surface is `ProgressUI`, `Options`, `Progressable`, `Shape`, `GrowDirection`, `ProgressSize`. Treat changes to these as semver-relevant.
+- Configuration flows through `Options` — prefer adding a field there over adding new initializers on `ProgressUI`.
+- State-driven coloring is opt-in via the generic `statusType:` parameter taking a `Progressable.Type`.
+- Keep view-extension files (`ProgressUI+*.swift`) split by concern rather than collapsing into the main view file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,14 @@ SwiftUI library providing a customizable circular/linear progress indicator. Dis
 
 ```bash
 swift build                    # build the library
+swift test                     # run the ProgressUITests suite
 swift build -c release         # release build
-xcodebuild -scheme ProgressUI -destination 'platform=iOS Simulator,name=iPhone 15' build
+xcodebuild -scheme ProgressUI -destination 'generic/platform=iOS Simulator' build
 ```
 
-There is no test target. To exercise changes interactively, open `Example/Example.xcodeproj` (iOS/macOS/watchOS targets) and run the `Example` scheme.
+Unit tests live in `Tests/ProgressUITests/` (XCTest). To exercise UI changes interactively, open `Example/Example.xcodeproj` (iOS/macOS/watchOS targets) and run the `Example` scheme.
+
+> If a bare `swift build`/`swift test` fails with an SDK/compiler mismatch (e.g. "failed to build module 'Darwin'… SDK is built with a different Swift version"), the `swift` on `PATH` is an older standalone toolchain (e.g. swiftly) that doesn't match the Xcode SDK. Run via Xcode's toolchain instead: `xcrun swift build` / `xcrun swift test`.
 
 ## Layout
 
@@ -33,3 +36,13 @@ There is no test target. To exercise changes interactively, open `Example/Exampl
 - Configuration flows through `Options` — prefer adding a field there over adding new initializers on `ProgressUI`.
 - State-driven coloring is opt-in via the generic `statusType:` parameter taking a `Progressable.Type`.
 - Keep view-extension files (`ProgressUI+*.swift`) split by concern rather than collapsing into the main view file.
+
+## Branching & releases (Git Flow)
+
+- `main` — stable, release-only. Every commit on `main` corresponds to a tagged release; never commit feature work directly here.
+- `develop` — the integration branch. All day-to-day work merges here first.
+- `feature/*` — branch off `develop`, merge back into `develop` via PR. CI (build + test across all platforms) must be green before merge.
+- `release/*` — cut from `develop` when preparing a version: bump the version, finalize `CHANGELOG.md`, then merge into both `main` (tagged) and `develop`.
+- `hotfix/*` — branch off `main` for urgent fixes, merge into both `main` (tagged) and `develop`.
+- Tag releases with semantic versions (`MAJOR.MINOR.PATCH`); public-API changes to the types above drive the version bump. Update `CHANGELOG.md` under `[Unreleased]` as you go.
+- Open PRs against `develop` (not `main`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to ProgressUI
+
+Thanks for your interest in improving ProgressUI! This document covers the
+essentials for contributing.
+
+## Getting started
+
+1. Fork the repository and create a feature branch off `develop`:
+   ```bash
+   git checkout -b feature/my-feature develop
+   ```
+2. Make your change.
+3. Build and test:
+   ```bash
+   swift build
+   swift test
+   ```
+4. For UI changes, run the sample app in `Example/Example.xcodeproj` (iOS,
+   macOS, and watchOS targets are available) to verify behavior interactively.
+
+## Project layout
+
+- `Sources/ProgressUI/` — the library. Public API surface is `ProgressUI`,
+  `Options`, `Progressable`, `Shape`, `GrowDirection`, and `ProgressSize`.
+- `Tests/ProgressUITests/` — XCTest unit tests.
+- `Example/` — multi-platform sample app.
+
+## Guidelines
+
+- **Platform availability.** The package supports iOS 14+, macOS 11+,
+  macCatalyst 14+, watchOS 7+, tvOS 15+, and visionOS 1+. Any new API must be
+  available on all of these.
+- **Configuration flows through `Options`.** Prefer adding a field to `Options`
+  (and a matching `set…` modifier) over adding new initializers to `ProgressUI`.
+- **Public API is semver-relevant.** Treat changes to the public types above as
+  breaking unless they are purely additive.
+- **Document public API** with `///` or `/** */` doc comments, and update the
+  DocC landing page (`Sources/ProgressUI/ProgressUI.docc/ProgressUI.md`) when
+  adding new public symbols.
+- **Add tests** for new logic where practical.
+- **Update `CHANGELOG.md`** under `[Unreleased]`.
+
+## Pull requests
+
+Open pull requests against `develop`. CI builds and tests across all supported
+platforms; please make sure it is green before requesting review.

--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,8 @@ let package = Package(
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
             name: "ProgressUI"),
-
+        .testTarget(
+            name: "ProgressUITests",
+            dependencies: ["ProgressUI"]),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,10 @@ let package = Package(
             name: "ProgressUI",
             targets: ["ProgressUI"]),
     ],
+    dependencies: [
+        // Build-tool plugin only; does not affect the library's runtime dependencies.
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+    ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.

--- a/README.md
+++ b/README.md
@@ -53,11 +53,9 @@ enum StorageStatus: CaseIterable, Progressable {
     case warning
     case critical
     case full
-    
-    var color: Color { innerColor.opacity(0.4) }
-    
-    // Optional: Add inner color for layered effect
-    var innerColor: Color? {
+
+    // Main (outer) progress color
+    var color: Color {
         switch self {
         case .safe:     return .green
         case .warning:  return .yellow
@@ -65,17 +63,16 @@ enum StorageStatus: CaseIterable, Progressable {
         case .full:     return .red
         }
     }
-    
-    static func calculate(from progress: CGFloat) -> Status {
-        let level: CGFloat = CGFloat(1) / CGFloat(Status.allCases.count)
-        
-        return switch progress {
-            case 0...level:                 Excellent
-            case level...(level * 2):       Normal
-            case (level * 2)...(level * 3): SemiNormal
-            case (level * 3)...(level * 4): Bad
-            case (level * 4)...(level * 5): Critical
-            default:                        Danger
+
+    // Optional: inner color for a layered effect
+    var innerColor: Color? { color.opacity(0.4) }
+
+    static func calculate(from progress: CGFloat) -> StorageStatus {
+        switch progress {
+        case ..<0.25: return .safe
+        case ..<0.5:  return .warning
+        case ..<0.75: return .critical
+        default:      return .full
         }
     }
 }
@@ -125,8 +122,8 @@ let options = Options(
     isClockwise: true,         // Rotation direction
     growFrom: .end,            // Growth direction
     isSpinner: false,          // Enable spinner mode
-    spinnerCycleDuration: 2    // Duration of spinner rotation
-    shape: .circular           // Duration of spinner rotation
+    spinnerCycleDuration: 2,   // Duration of a full spinner cycle (seconds)
+    shape: .circular           // Progress shape (.circular or .linear)
 )
 ```
 

--- a/Sources/ProgressUI/Options.swift
+++ b/Sources/ProgressUI/Options.swift
@@ -10,6 +10,60 @@ import SwiftUI
 /// Options for customizing the appearance and behavior of ProgressUI.
 public struct Options {
 	/**
+	 Creates a configuration for ``ProgressUI``.
+
+	 Every parameter has a default, so you only need to specify the values you
+	 want to override, e.g. `Options(isRounded: false, progressColor: .blue)`.
+
+	 - Parameters:
+	    - size: The size preset. Default: ``ProgressSize/large``.
+	    - trackColor: The color of the empty track. Default: `Color.black`.
+	    - trackWidth: An explicit track width. Default: `nil` (derived from `size`).
+	    - progressColor: The progress color. Default: `Color.green`.
+	    - animationMaxValue: Progress threshold for the start-of-growth width animation. `nil` disables it. Default: `0.03`.
+	    - animation: The animation applied to progress changes. Default: `.easeInOut(duration: 0.5)`.
+	    - innerProgressWidth: An explicit inner progress width. Default: `nil` (derived from `size`).
+	    - innerProgressColor: The inner progress color. Default: `Color.black.opacity(0.2)`.
+	    - isRounded: Whether line caps are rounded. Default: `true`.
+	    - isClockwise: Whether the spinner rotates clockwise. Default: `true`.
+	    - growFrom: The direction the progress grows from. Default: ``GrowDirection/end``.
+	    - isSpinner: Whether to run in indeterminate spinner mode. Default: `false`.
+	    - spinnerCycleDuration: Seconds for one full spinner cycle. Default: `1`.
+	    - shape: The progress shape. Default: ``Shape/circular``.
+	 */
+	public init(
+		size: ProgressSize = .large,
+		trackColor: Color = .black,
+		trackWidth: CGFloat? = nil,
+		progressColor: Color = .green,
+		animationMaxValue: CGFloat? = 0.03,
+		animation: Animation = .easeInOut(duration: 0.5),
+		innerProgressWidth: CGFloat? = nil,
+		innerProgressColor: Color? = .black.opacity(0.2),
+		isRounded: Bool = true,
+		isClockwise: Bool = true,
+		growFrom: GrowDirection = .end,
+		isSpinner: Bool = false,
+		spinnerCycleDuration: TimeInterval = 1,
+		shape: Shape = .circular
+	) {
+		self.size = size
+		self.trackColor = trackColor
+		self.trackWidth = trackWidth
+		self.progressColor = progressColor
+		self.animationMaxValue = animationMaxValue
+		self.animation = animation
+		self.innerProgressWidth = innerProgressWidth
+		self.innerProgressColor = innerProgressColor
+		self.isRounded = isRounded
+		self.isClockwise = isClockwise
+		self.growFrom = growFrom
+		self.isSpinner = isSpinner
+		self.spinnerCycleDuration = spinnerCycleDuration
+		self.shape = shape
+	}
+
+	/**
 	 The size of the circle.
 	 
 	 Default: ``ProgressSize/large``.

--- a/Sources/ProgressUI/ProgressUI.docc/ProgressUI.md
+++ b/Sources/ProgressUI/ProgressUI.docc/ProgressUI.md
@@ -1,0 +1,52 @@
+# ``ProgressUI``
+
+A highly customizable circular and linear progress indicator for SwiftUI.
+
+## Overview
+
+`ProgressUI` renders determinate or indeterminate progress with dynamic,
+state-driven coloring, multiple size presets, adjustable stroke widths and line
+caps, and smooth animations. It runs on iOS, macOS, macCatalyst, watchOS, tvOS,
+and visionOS.
+
+```swift
+import SwiftUI
+import ProgressUI
+
+struct ContentView: View {
+    var body: some View {
+        ProgressUI(progress: 0.5)
+    }
+}
+```
+
+Customize appearance either by passing an ``Options`` value or by chaining the
+`set…` modifiers:
+
+```swift
+ProgressUI(progress: 0.5, options: Options(progressColor: .blue, isRounded: false))
+
+ProgressUI(progress: 0.5)
+    .setProgressColor(.blue)
+    .setIsRounded(false)
+```
+
+Drive coloring from progress state by conforming a `CaseIterable` type to
+``Progressable`` and passing it as `statusType:`.
+
+## Topics
+
+### Creating a progress indicator
+
+- ``ProgressUI/ProgressUI``
+
+### Configuration
+
+- ``Options``
+- ``ProgressSize``
+- ``Shape``
+- ``GrowDirection``
+
+### Dynamic coloring
+
+- ``Progressable``

--- a/Tests/ProgressUITests/GrowDirectionTests.swift
+++ b/Tests/ProgressUITests/GrowDirectionTests.swift
@@ -1,0 +1,19 @@
+//
+//  GrowDirectionTests.swift
+//  ProgressUI
+//
+
+import XCTest
+import SwiftUI
+@testable import ProgressUI
+
+final class GrowDirectionTests: XCTestCase {
+
+	/// `alignment` is the internal bridge GrowDirection uses to position the growing arc;
+	/// each case must map to the matching SwiftUI alignment.
+	func testAlignmentMapping() {
+		XCTAssertEqual(GrowDirection.start.alignment, .leading)
+		XCTAssertEqual(GrowDirection.center.alignment, .center)
+		XCTAssertEqual(GrowDirection.end.alignment, .trailing)
+	}
+}

--- a/Tests/ProgressUITests/OptionsTests.swift
+++ b/Tests/ProgressUITests/OptionsTests.swift
@@ -1,0 +1,76 @@
+//
+//  OptionsTests.swift
+//  ProgressUI
+//
+
+import XCTest
+import SwiftUI
+@testable import ProgressUI
+
+final class OptionsTests: XCTestCase {
+
+	func testDefaultsMatchDocumentedValues() {
+		let options = Options()
+
+		XCTAssertEqual(options.trackColor, .black)
+		XCTAssertEqual(options.progressColor, .green)
+		XCTAssertEqual(options.animationMaxValue, 0.03)
+		XCTAssertNil(options.trackWidth)
+		XCTAssertNil(options.innerProgressWidth)
+		XCTAssertEqual(options.innerProgressColor, .black.opacity(0.2))
+		XCTAssertTrue(options.isRounded)
+		XCTAssertTrue(options.isClockwise)
+		XCTAssertFalse(options.isSpinner)
+		XCTAssertEqual(options.spinnerCycleDuration, 1)
+
+		// GrowDirection / ProgressSize / Shape aren't Equatable — pattern-match instead.
+		XCTAssertEqual(options.growFrom.alignment, .trailing) // .end
+		guard case .large = options.size else {
+			return XCTFail("default size should be .large")
+		}
+		guard case .circular = options.shape else {
+			return XCTFail("default shape should be .circular")
+		}
+	}
+
+	/// The public memberwise init must let consumers override only the fields they care about.
+	func testPublicInitOverridesSelectedFields() {
+		let options = Options(
+			trackColor: .gray,
+			progressColor: .blue,
+			isRounded: false,
+			growFrom: .center,
+			isSpinner: true,
+			spinnerCycleDuration: 2
+		)
+
+		XCTAssertEqual(options.trackColor, .gray)
+		XCTAssertEqual(options.progressColor, .blue)
+		XCTAssertFalse(options.isRounded)
+		XCTAssertEqual(options.growFrom.alignment, .center)
+		XCTAssertTrue(options.isSpinner)
+		XCTAssertEqual(options.spinnerCycleDuration, 2)
+
+		// Untouched fields keep their defaults.
+		XCTAssertEqual(options.animationMaxValue, 0.03)
+		XCTAssertTrue(options.isClockwise)
+	}
+
+	func testLinearShapeCarriesPadding() {
+		let options = Options(shape: .linear(20))
+		guard case .linear(let padding) = options.shape else {
+			return XCTFail("expected linear shape")
+		}
+		XCTAssertEqual(padding, 20)
+	}
+
+	func testLinearShapeDefaultPadding() {
+		// `Shape` (the package enum) collides with `SwiftUI.Shape`, and the
+		// `ProgressUI` type name shadows the module — so reach the value via Options.
+		let options = Options(shape: .linear())
+		guard case .linear(let padding) = options.shape else {
+			return XCTFail("expected linear shape")
+		}
+		XCTAssertEqual(padding, 15)
+	}
+}

--- a/Tests/ProgressUITests/ProgressableTests.swift
+++ b/Tests/ProgressUITests/ProgressableTests.swift
@@ -1,0 +1,72 @@
+//
+//  ProgressableTests.swift
+//  ProgressUI
+//
+
+import XCTest
+import SwiftUI
+@testable import ProgressUI
+
+/// A four-bucket sample status, mirroring the README's StorageStatus example.
+private enum SampleStatus: CaseIterable, Progressable, Equatable {
+	case safe, warning, critical, full
+
+	var color: Color {
+		switch self {
+		case .safe:     return .green
+		case .warning:  return .yellow
+		case .critical: return .orange
+		case .full:     return .red
+		}
+	}
+
+	var innerColor: Color? { color.opacity(0.4) }
+
+	static func calculate(from progress: CGFloat) -> SampleStatus {
+		switch progress {
+		case ..<0.25: return .safe
+		case ..<0.5:  return .warning
+		case ..<0.75: return .critical
+		default:      return .full
+		}
+	}
+}
+
+/// A status that omits `innerColor` to exercise the protocol's default implementation.
+private enum MinimalStatus: CaseIterable, Progressable, Equatable {
+	case low, high
+
+	var color: Color { self == .low ? .green : .red }
+
+	static func calculate(from progress: CGFloat) -> MinimalStatus {
+		progress < 0.5 ? .low : .high
+	}
+}
+
+final class ProgressableTests: XCTestCase {
+
+	func testCalculateBuckets() {
+		XCTAssertEqual(SampleStatus.calculate(from: 0), .safe)
+		XCTAssertEqual(SampleStatus.calculate(from: 0.24), .safe)
+		XCTAssertEqual(SampleStatus.calculate(from: 0.25), .warning)
+		XCTAssertEqual(SampleStatus.calculate(from: 0.49), .warning)
+		XCTAssertEqual(SampleStatus.calculate(from: 0.5), .critical)
+		XCTAssertEqual(SampleStatus.calculate(from: 0.74), .critical)
+		XCTAssertEqual(SampleStatus.calculate(from: 0.75), .full)
+		XCTAssertEqual(SampleStatus.calculate(from: 1), .full)
+	}
+
+	/// Out-of-range values fall through to the final bucket rather than trapping.
+	func testCalculateClampsBeyondRange() {
+		XCTAssertEqual(SampleStatus.calculate(from: 5), .full)
+	}
+
+	func testInnerColorDefaultsToNil() {
+		XCTAssertNil(MinimalStatus.low.innerColor)
+		XCTAssertNil(MinimalStatus.high.innerColor)
+	}
+
+	func testInnerColorWhenProvided() {
+		XCTAssertEqual(SampleStatus.safe.innerColor, Color.green.opacity(0.4))
+	}
+}


### PR DESCRIPTION
## 📋 Description

Hardens the package for public contributors and fixes a latent public-API bug.

- **`Options` public init** — the synthesized memberwise initializer was *internal-only*, so `Options(...)` could not be constructed from a consumer module (only `.setX()` modifiers worked). Adds an explicit `public init` preserving all defaults.
- **Tests** — new `ProgressUITests` target (9 tests): `Options` defaults/init, `Progressable.calculate(from:)` bucketing, `GrowDirection` alignment.
- **CI** — `actions/checkout@v4`, runs `swift test`, builds across all 6 advertised platforms; push scoped to `main` + concurrency to avoid redundant runs.
- **DocC → GitHub Pages** — `swift-docc-plugin` + a workflow that publishes the `ProgressUI.docc` catalog on push to `main`.
- **Docs** — fixed two uncompilable README examples; added `CHANGELOG.md`, `CONTRIBUTING.md`, DocC landing page, and Git Flow conventions in `CLAUDE.md`.
- **Templates** — moved the PR template to `.github/PULL_REQUEST_TEMPLATE.md` so it auto-applies; added a required ProgressUI-version field to the bug report; refreshed Xcode/iOS example versions to 26.

## 🔄 Type of Change

- [x] 🐛 Bug fix (public `Options` init)
- [x] ✨ New feature (tests, DocC Pages)
- [x] 📝 Documentation update
- [x] 🔧 Refactor or internal change (CI)

## ✅ How Has This Been Tested?

- `xcrun swift test` → **9 tests, 0 failures**.
- `xcrun swift build` green; DocC generation validated locally (produces `index.html`).

### Test Summary
- [x] Unit tests
- [ ] UI/Integration tests
- [x] Manual (DocC build)

> ⚠️ Setup prerequisite: enable **Pages → Source: GitHub Actions** in repo settings for the docs workflow to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)