### PR TITLE
Set least-privilege permissions on Build & Test workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ on:
   push:
     branches: [main]
 
+# Least-privilege GITHUB_TOKEN — these jobs only check out and build.
+permissions:
+  contents: read
+
 # Cancel superseded runs for the same ref (e.g. rapid pushes to an open PR).
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/Tests/ProgressUITests/GrowDirectionTests.swift
+++ b/Tests/ProgressUITests/GrowDirectionTests.swift
@@ -2,6 +2,8 @@
 //  GrowDirectionTests.swift
 //  ProgressUI
 //
+//  Created by Pierre Janineh on 30/05/2026.
+//
 
 import XCTest
 import SwiftUI

--- a/Tests/ProgressUITests/OptionsTests.swift
+++ b/Tests/ProgressUITests/OptionsTests.swift
@@ -2,6 +2,8 @@
 //  OptionsTests.swift
 //  ProgressUI
 //
+//  Created by Pierre Janineh on 30/05/2026.
+//
 
 import XCTest
 import SwiftUI

--- a/Tests/ProgressUITests/ProgressableTests.swift
+++ b/Tests/ProgressUITests/ProgressableTests.swift
@@ -2,6 +2,8 @@
 //  ProgressableTests.swift
 //  ProgressUI
 //
+//  Created by Pierre Janineh on 30/05/2026.
+//
 
 import XCTest
 import SwiftUI


### PR DESCRIPTION
## 📋 Description

CI hardening plus a small source-header cleanup.

- **Workflow permissions** — resolves two CodeQL alerts (`actions/missing-workflow-permissions`, medium) by adding a top-level `permissions: contents: read` to `build.yml`. Both jobs only check out and build, so read-only is sufficient. (`docs.yml` already scoped its token.)
- **Test file headers** — the three `ProgressUITests` files were created without the project's standard `// Created by Pierre Janineh on …` header block; added to match every other source file.

## 🔄 Type of Change

- [x] 🔧 Refactor or internal change (CI hardening)
- [x] 📝 Documentation update (file headers)

## ✅ How Has This Been Tested?

- `build.yml` YAML validated (parses; `permissions: {contents: read}`, both jobs intact).
- CI re-runs on this PR; CodeQL should clear the permissions alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)