### PR TITLE
Back-merge 1.1.0 release prep into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-05-31
+
 ### Added
-- Public memberwise initializer for ``Options``, allowing consumers to construct
+- Public memberwise initializer for `Options`, allowing consumers to construct
   a configuration directly (e.g. `Options(progressColor: .blue)`) instead of
   only through the `set…` modifiers.
 - Unit test target (`ProgressUITests`) covering `Options` defaults, the new
@@ -27,3 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Corrected the README "Dynamic Colors" and "Customization Options" examples,
   which previously did not compile.
+- Resolved DocC symbol-link warnings in the `Options.size`/`setSize(_:)` size
+  tables and the `GrowDirection.end` default links; DocC now builds cleanly.
+
+### Security
+- Set a least-privilege `GITHUB_TOKEN` (`contents: read`) on the Build & Test
+  workflow, resolving the CodeQL `actions/missing-workflow-permissions` alerts.
+
+[Unreleased]: https://github.com/PierreJanineh-com/ProgressUI/compare/1.1.0...HEAD
+[1.1.0]: https://github.com/PierreJanineh-com/ProgressUI/compare/1.0.4...1.1.0

--- a/Sources/ProgressUI/Components/ProgressUI/ProgressUI+Modifiers.swift
+++ b/Sources/ProgressUI/Components/ProgressUI/ProgressUI+Modifiers.swift
@@ -14,9 +14,9 @@ extension ProgressUI {
 	///
 	/// Default: ``ProgressSize/large``.
 	///
-	/// ``ProgressSize/large`` > ``trackWidth`` `= 45`,  ``progressLineWidth`` `= 10`,  ``progressInnerLineWidth`` `= 5`,   ``radius`` `= 60`
+	/// ``ProgressSize/large`` > `trackWidth = 45`, `progressLineWidth = 10`, `progressInnerLineWidth = 5`, `radius = 60`
 	///
-	/// ``ProgressSize/small`` > ``trackWidth`` = `15`,  ``progressLineWidth`` `= 5`,  ``progressInnerLineWidth`` `= 2.5`,  ``radius`` `= 30`
+	/// ``ProgressSize/small`` > `trackWidth = 15`, `progressLineWidth = 5`, `progressInnerLineWidth = 2.5`, `radius = 30`
 	public func setSize(_ size: ProgressSize) -> Self {
 		var copy = self
 		copy.options.size = size
@@ -129,10 +129,10 @@ extension ProgressUI {
 	}
 	
 	/// Sets the direction the progress arc growth.
-	/// - Parameter from: Growing animation direction (default: .end).
+	/// - Parameter direction: Growing animation direction (default: .end).
 	/// - Returns: A modified ProgressUI instance.
 	///
-	/// Default: ``ProgressUI/GrowDirection/end.
+	/// Default: ``GrowDirection/end``.
 	///
 	/// > Setting this value to ``ProgressUI/GrowDirection/center`` with rotation 
 	public func setGrow(from direction: GrowDirection = .end) -> Self {

--- a/Sources/ProgressUI/Options.swift
+++ b/Sources/ProgressUI/Options.swift
@@ -68,9 +68,9 @@ public struct Options {
 	 
 	 Default: ``ProgressSize/large``.
 	 
-	 ``ProgressSize/large`` > ``trackWidth`` `= 45`,  ``progressLineWidth`` `= 10`,  ``progressInnerLineWidth`` `= 5`,   ``radius`` `= 60`
-	 
-	 ``ProgressSize/small`` > ``trackWidth`` = `15`,  ``progressLineWidth`` `= 5`,  ``progressInnerLineWidth`` `= 2.5`,  ``radius`` `= 30`
+	 ``ProgressSize/large`` > `trackWidth = 45`, `progressLineWidth = 10`, `progressInnerLineWidth = 5`, `radius = 60`
+
+	 ``ProgressSize/small`` > `trackWidth = 15`, `progressLineWidth = 5`, `progressInnerLineWidth = 2.5`, `radius = 30`
 	 
 	 > You can set this with the modifier ``ProgressUI/ProgressUI/setSize(_:)``.
 	 */
@@ -160,7 +160,7 @@ public struct Options {
 	/**
 	 Determines where the growing animation should go.
 	 
-	 Default: ``ProgressUI/GrowDirection/end.
+	 Default: ``GrowDirection/end``.
 	 
 	 > You can set this with the modifier ``ProgressUI/ProgressUI/setGrow(from:)``.
 	 */


### PR DESCRIPTION
## 📋 Description

Git Flow back-merge: brings the `release/1.1.0` prep commits into `develop` after the 1.1.0 release was tagged on `main`.

Diff vs `develop` is just the two release-prep commits:
- DocC symbol-link warning fixes (docs now build with 0 warnings)
- CHANGELOG finalized for 1.1.0

No source/behavior changes beyond doc comments + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)