### PR TITLE
Hotfix: redirect docs site root to module documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,6 +33,25 @@ jobs:
             --hosting-base-path ProgressUI \
             --output-path ./docs
 
+      # DocC has no landing page at the site root, so the bare Pages URL renders
+      # "page can't be found". Redirect the root to the module's documentation.
+      - name: Redirect site root to the module documentation
+        run: |
+          cat > ./docs/index.html <<'HTML'
+          <!DOCTYPE html>
+          <html lang="en">
+            <head>
+              <meta charset="utf-8">
+              <title>ProgressUI</title>
+              <meta http-equiv="refresh" content="0; url=documentation/progressui">
+              <link rel="canonical" href="documentation/progressui">
+            </head>
+            <body>
+              Redirecting to the <a href="documentation/progressui">ProgressUI documentation</a>…
+            </body>
+          </html>
+          HTML
+
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs


### PR DESCRIPTION
## 📋 Description

Post-1.1.0 docs-site hotfix. The bare GitHub Pages URL (`…github.io/ProgressUI/`) rendered DocC's "page can't be found" because a DocC site has no root landing page — the module lives at `/documentation/progressui`.

This adds a workflow step that overwrites the generated root `index.html` with a redirect to `documentation/progressui`. Per-route pages have their own `index.html`, so deep links are unaffected.

- No library/source changes — workflow only. No version bump.
- Redeploys Pages on merge to `main`.

## 🔄 Type of Change
- [x] 🐛 Bug fix (docs deployment)

## ✅ Tested
- `docs.yml` YAML validated.
- Verified the deep URL already serves (200) and the per-route page exists, so replacing the root is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)